### PR TITLE
Inhibit .beam file generation at compilation time

### DIFF
--- a/test/beam_patch_test.exs
+++ b/test/beam_patch_test.exs
@@ -107,4 +107,14 @@ defmodule BeamPatchTest do
                    fn -> BeamPatch.patch_quoted!(NoDebugInfoModule, nil) end
     end
   end
+
+  describe "compilation-time patching" do
+    test "doesn't leave a .beam file" do
+      assert {:error, :nofile} = Code.ensure_loaded(BeamPatch.InjectedCode)
+    end
+
+    test "doesn't leave the module loaded" do
+      refute Code.loaded?(BeamPatch.InjectedCode)
+    end
+  end
 end

--- a/test/fixtures/compile_time_patch.ex
+++ b/test/fixtures/compile_time_patch.ex
@@ -1,0 +1,8 @@
+defmodule CompileTimePatch do
+  @moduledoc false
+  require BeamPatch
+
+  @patch BeamPatch.patch_quoted!(String, do: nil)
+
+  def patch, do: @patch
+end


### PR DESCRIPTION
Normally, calling `Code.compile_quoted/2` during compilation time generates a .beam file. This is not what we want for the injected code, so this commit prevents it by stashing the process dictionary while compiling `BeamPatch.InjectedCode`.