### PR TITLE
Manually purge the BeamPatch.InjectedCode module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# v0.2.1 (Unreleased)
+
+* Elixir 1.19 compatibility - manually unload the temporary `BeamPatch.InjectedCode` module
+    * Elixir 1.19 ignores `@compile {:autoload, false}` when the compiled module is not saved to disk
+


### PR DESCRIPTION
Elixir 1.19 (as of RC0) does not honor `@compile {:autoload, false}` on modules that are not saved to disk. Although harmless, to ensure `BeamPatch.InjectedCode` doesn't linger we need to manually unload it after compilation.